### PR TITLE
Added initial documentation to describe the fortran calculations used by core.py

### DIFF
--- a/src/xcape/Bunkers_model_lev.f90
+++ b/src/xcape/Bunkers_model_lev.f90
@@ -16,7 +16,8 @@
 !  model level, or 10m AGL winds). Data are interpolated to 13 fixed layers at
 !  500m intervals following the optimal method for surface-based storms, and
 !  storm motion calculated using the empirically determined propagation of
-!  7.5 m/s orthogonal to the 0-6km mean wind as a ratio to the 0-6km mean shear.!  Returns storm motions for the inferred right (V_{RM}) and left (V_{LM})
+!  7.5 m/s orthogonal to the 0-6km mean wind as a ratio to the 0-6km mean shear.
+!  Returns storm motions for the inferred right (V_{RM}) and left (V_{LM})
 !  moving supercells, along with the 0-6km mean wind.   
 !  
 !  Equations:

--- a/src/xcape/Bunkers_model_lev.f90
+++ b/src/xcape/Bunkers_model_lev.f90
@@ -9,10 +9,37 @@
 !
 !  Disclaimer:  This code is made available WITHOUT WARRANTY.
 !-----------------------------------------------------------------------
-!  U3d,V3d = zonal and meridional wind
-!  AGLH3d = above ground level height
-!  nk = number of pressure levels
-!  n2 = number of grid point for which calculate RM,LM,Mean6kmwind
+!  Description:
+!  Looping subroutine to apply the Bunkers et al. [2000] internal dynamics 
+!  method for estimating supercell storm motion for a 2D-array (n2,nk) 
+!  of vector winds at known heights, and near surface winds (either lowest
+!  model level, or 10m AGL winds). Data are interpolated to 13 fixed layers at
+!  500m intervals following the optimal method for surface-based storms, and
+!  storm motion calculated using the empirically determined propagation of
+!  7.5 m/s orthogonal to the 0-6km mean wind as a ratio to the 0-6km mean shear.!  Returns storm motions for the inferred right (V_{RM}) and left (V_{LM})
+!  moving supercells, along with the 0-6km mean wind.   
+!  
+!  Equations:
+!  V_{RM}= V_{mean} \plus 7.5\times[\frac{V_{shear}\times \uvec{k}}{\| V_{shear}
+!  \|}]  
+!  
+!  V_{LM}= V_{mean} \minus 7.5\times[\frac{ \uvec{k}\times V_{shear}}{\|
+!  V_{shear} \|}]   
+!
+!  For further details see: 
+!  Bunkers et al. [2000]: Predicting supercell motion using a new hodograph
+!  technique. Weather and forecasting, 15(1), 61-79.
+!-----------------------------------------------------------------------
+!  Inputs:
+!  U3d,V3d = 2D zonal and meridional winds of shape (n2,nk). Units m/s.
+!  AGLH3d = above ground level height of shape (n2, nk). Units m.
+!  nk = number of levels (model or pressure) of shape (nk). Integer.
+!  n2 = collapsed dimension of grid points for which calculate motions. Integer.
+!
+!  Outputs: 
+!  RM = Right-moving storm motion (assuming a supercell) of shape (n2) in m/s.
+!  LM = Left-moving storm motion (assuming a supercell) of shape (n2) in m/s.
+!  Mean6kmwind = 0-6km Mean Wind calculated as an intemediary in m/s.
 !-----------------------------------------------------------------------
     implicit none
 
@@ -52,9 +79,18 @@
 !
 !  Disclaimer:  This code is made available WITHOUT WARRANTY.
 !-----------------------------------------------------------------------
-!  U,V = zonal and meridional wind
-!  AGLH = above ground level height
-!  nk = number of pressure levels
+!  Description:
+!  Subroutine to perform pointwise the operation described in bunkers_loop.
+!-----------------------------------------------------------------------
+!  Input:
+!  U,V = zonal and meridional wind for a single grid point (m/s) of shape nk.
+!  AGLH = above ground level height for a single grid point (m) of shape nk. 
+!  nk = number of levels. Integer.
+!   
+!  Output: 
+!  RM = Right-moving storm motion (assuming a supercell) in m/s.
+!  LM = Left-moving storm motion (assuming a supercell) in m/s.
+!  Mean6kmwind = 0-6km Mean Wind calculated as an intemediary in m/s.
 !-----------------------------------------------------------------------
     implicit none
 
@@ -144,6 +180,8 @@
 
 !-----------------------------------------------------------------------
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+! DINTER2DZ - Subroutine to perform an interpolation to fixed values over
+! an unstructured grid.  
 !-----------------------------------------------------------------------
 
     SUBROUTINE DINTERP2DZ(V3D,Z,LOC,V2D,N2,NZ)

--- a/src/xcape/Bunkers_model_lev.pyf
+++ b/src/xcape/Bunkers_model_lev.pyf
@@ -1,5 +1,7 @@
 !    -*- f90 -*-
 ! Note: the context of this file is case sensitive.
+! Python Wrapper for the functions needed to generate a Bunkers et al. [2000]
+! derived storm motion for n-dimensional model data. 
 
 python module Bunkers_model_lev ! in 
     interface  ! in :Bunkers_model_lev

--- a/src/xcape/srh.py
+++ b/src/xcape/srh.py
@@ -1,6 +1,36 @@
 
 def srh(u_2d, v_2d, aglh_2d, u_s, v_s, aglh_s, pres_lev_pos, depth, type_grid, output):
-    
+     ''' 
+     Description:
+     ------------
+     Function called by calc_srh (core.py) to perform Bunkers storm motion 
+     and derived SRH calculations for specified depth using the wrapped 
+     compiled fortran code for either pressure level or model level data 
+     on 2-dimensions (collapsed grid and vertical) which are specified 
+     in the call to this function. For full description, see function 
+     calc_srh in core.py, or in Bunkers_model_lev.f90.
+     
+     Parameters:
+     ------------ 
+     u_2d,v_2d :    'array-like' 
+                    Gridded component winds in m/s (nk, ngrid). 
+     aglh_2d:       'array-like'
+                    Gridded height above ground level in m (nk, ngrid).
+     u_s,v_s:       'array-like'
+                    Component winds at the lowest model level or surface in m/s.
+                    (ngrid).
+     aglh_s:        'array-like'
+                    Height of the surface level above ground level in m (ngrid)
+     press_lev_pos: '?'
+                    Need to Add
+     depth:         'Integer'
+                    Depth for SRH integration to be performed in m. 
+     type_grid:     'Integer'
+                    Whether the input data is 'sigma':1 or 'pressure':2 level.
+     output:        'Integer'
+                    If set to 1, only return SRH, otherwise return SRH and 
+                    motions.
+     '''        
                 
     # nlev has to be the first dimension
     # nlev here is the number of levels in 3d variables (without surface level)

--- a/src/xcape/srh.py
+++ b/src/xcape/srh.py
@@ -1,6 +1,6 @@
 
 def srh(u_2d, v_2d, aglh_2d, u_s, v_s, aglh_s, pres_lev_pos, depth, type_grid, output):
-     ''' 
+    """        
      Description:
      ------------
      Function called by calc_srh (core.py) to perform Bunkers storm motion 
@@ -9,7 +9,7 @@ def srh(u_2d, v_2d, aglh_2d, u_s, v_s, aglh_s, pres_lev_pos, depth, type_grid, o
      on 2-dimensions (collapsed grid and vertical) which are specified 
      in the call to this function. For full description, see function 
      calc_srh in core.py, or in Bunkers_model_lev.f90.
-     
+
      Parameters:
      ------------ 
      u_2d,v_2d :    'array-like' 
@@ -30,7 +30,7 @@ def srh(u_2d, v_2d, aglh_2d, u_s, v_s, aglh_s, pres_lev_pos, depth, type_grid, o
      output:        'Integer'
                     If set to 1, only return SRH, otherwise return SRH and 
                     motions.
-     '''        
+    """        
                 
     # nlev has to be the first dimension
     # nlev here is the number of levels in 3d variables (without surface level)


### PR DESCRIPTION
First commit - add Bunkers method for storm motion applied in both the PYF wrapper and .f90 file for model levels only. Do we need to duplicate this into the pressure version, or is this redundant?